### PR TITLE
clean first line of alipayConfig.php

### DIFF
--- a/aop/AlipayConfig.php
+++ b/aop/AlipayConfig.php
@@ -1,4 +1,3 @@
-
 <?php
 class AlipayConfig {
     /**


### PR DESCRIPTION
删除AlipayConfig.php文件头空白行。在WordPress中引用sdk作为插件时，AlipayConfig.php文件头空行会设置 http headers，使得后续无法设置cookie以及跳转