### PR TITLE
Update AlipayConfig.php

### DIFF
--- a/v2/aop/AlipayConfig.php
+++ b/v2/aop/AlipayConfig.php
@@ -1,4 +1,3 @@
-
 <?php
 class AlipayConfig {
     /**


### PR DESCRIPTION
删除多余的换行符，会制造bug
这个多余的换行符会当做text输出，导致后续的代码无法调用header()